### PR TITLE
Cleanup globus legacy api, minor docs cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Unit tests & documentation for code in this repo is not required.
 
 To start server
 ---------------
+clone kbase/jars into the parent folder of this repo  
 ant compile  
 ant buildwar  
 install jetty (see jetty-config.md for version)  

--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@ Unit tests & documentation for code in this repo is not required.
 
 To start server
 ---------------
-ant compile
-ant buildwar
-install jetty (see jetty-config.md for version)
-./jettybase$ java -jar ~/jetty/jetty-distribution-9.3.11.v20160721/start.jar 
+ant compile  
+ant buildwar  
+install jetty (see jetty-config.md for version)  
+./jettybase$ java -jar ~/jetty/jetty-distribution-9.3.11.v20160721/start.jar   
 
 Start & stop server
 -------------------
-./jettybase$ java -DSTOP.PORT=8079 -DSTOP.KEY=foo -jar ~/jetty/jetty-distribution-9.3.11.v20160721/start.jar 
-./jettybase$ java -DSTOP.PORT=8079 -DSTOP.KEY=foo -jar ~/jetty/jetty-distribution-9.3.11.v20160721/start.jar --stop
+./jettybase$ java -DSTOP.PORT=8079 -DSTOP.KEY=foo -jar ~/jetty/jetty-distribution-9.3.11.v20160721/start.jar  
+./jettybase$ java -DSTOP.PORT=8079 -DSTOP.KEY=foo -jar ~/jetty/jetty-distribution-9.3.11.v20160721/start.jar --stop  
 
 Omit the stop key to have jetty generate one for you.
 

--- a/devnotes.md
+++ b/devnotes.md
@@ -9,9 +9,9 @@ Templates are mustache templates.
 Exception mapping
 -----------------
 
-in us.kbase.auth2.exceptions
-AuthException and subclasses other than the below - 400
-AuthenticationException and subclasses - 401
-UnauthorizedException and subclasses - 403
+in us.kbase.auth2.exceptions  
+AuthException and subclasses other than the below - 400  
+AuthenticationException and subclasses - 401  
+UnauthorizedException and subclasses - 403  
 
 Anything else is mapped to 500.


### PR DESCRIPTION
Globus throws a 403 rather than a 401 on a bad token
Globus supports both x-globus-goauth and globus-goauth in the header
